### PR TITLE
Do not handle unreachable states as failure

### DIFF
--- a/Sources/Engine/WSEngine.swift
+++ b/Sources/Engine/WSEngine.swift
@@ -121,7 +121,7 @@ FrameCollectorDelegate, HTTPHandlerDelegate {
             let data = httpHandler.convert(request: wsReq)
             transport.write(data: data, completion: {_ in })
         case .waiting:
-            break
+            broadcast(event: .waiting)
         case .failed(let error):
             handleError(error)
         case .viability(let isViable):

--- a/Sources/Starscream/WebSocket.swift
+++ b/Sources/Starscream/WebSocket.swift
@@ -84,6 +84,7 @@ public enum WebSocketEvent {
     case error(Error?)
     case viabilityChanged(Bool)
     case reconnectSuggested(Bool)
+    case waiting
     case cancelled
 }
 

--- a/Sources/Transport/TCPTransport.swift
+++ b/Sources/Transport/TCPTransport.swift
@@ -106,10 +106,10 @@ public class TCPTransport: Transport {
             case .ready:
                 self?.delegate?.connectionChanged(state: .connected)
             case .waiting(let error):
-                let failureCodes: [POSIXErrorCode] = [.ETIMEDOUT, .ENETDOWN, .ENETUNREACH]
+                let failureCodes: [POSIXErrorCode] = [.ETIMEDOUT]
                 switch error {
                 case .posix(let errorCode) where failureCodes.contains(errorCode):
-                    // handle timeout and networks unreachable
+                    // handle timeout
                     self?.delegate?.connectionChanged(state: .failed(error))
                 default:
                     self?.delegate?.connectionChanged(state: .waiting)


### PR DESCRIPTION
### Implementation Details 🚧
When on a LAN connection without Internet access, it should still be possible to connect to a local console and use websockets.

However, there might be an ENETDOWN or ENETUNREACH error (since Internet is down) and the websockets will close. We should not treat this as an error.

I also added a waiting state, so that we can use this to e.g. start a timeout, and only if the connection is not resolved within some short time interval, treat it as an error and attempt a reconnect.